### PR TITLE
fix(git): 修复 Android 13 以下初始化/打开 git 仓库闪退

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,8 +93,9 @@ android {
     }
     packaging {
         resources {
-            // 排除导致冲突的 JGit 配置文件
+            // 排除导致冲突的 JGit 配置文件（Eclipse OSGi 插件元数据，Android 运行时不使用）
             excludes += "OSGI-INF/l10n/plugin.properties"
+            excludes += "plugin.properties"
 
             // 如果后续还有类似冲突，通常也是 META-INF 下的文件，比如：
             excludes += "META-INF/DEPENDENCIES"
@@ -187,9 +188,22 @@ dependencies {
     // Source: https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit
     implementation(libs.org.eclipse.jgit)
     // Source: https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit.ssh.apache
-    implementation(libs.org.eclipse.jgit.ssh.apache)
+    implementation(libs.org.eclipse.jgit.ssh.apache) {
+        // sshd-osgi 是把 sshd-core + sshd-common 重新打包的 OSGi fat bundle，
+        // 在 Android（非 OSGi）上会与分离的 core/common 构件产生重复类和重复资源
+        //（如 org/apache/sshd/common/kex/group15.prime）。排除它，改用下面的分离构件。
+        exclude(group = "org.apache.sshd", module = "sshd-osgi")
+    }
     //noinspection UseTomlInstead
     implementation("org.slf4j:slf4j-simple:2.0.17")
+    // JGit 5.13.3 传递依赖 Apache MINA SSHD 2.7.0，但 2.7.0 缺少
+    // PathUtils.setUserHomeFolderResolver()（自 2.10.0 引入），该方法是 Android 上
+    // 重定向 SSH 用户主目录、避免 "No user home folder available" 崩溃的关键。
+    // 显式引入分离的 SSHD 2.10.0 构件（Java 8 字节码，不会引入 readNBytes），
+    // 替代被排除的 sshd-osgi fat bundle（sshd-osgi 不含独有类，仅聚合 core+common）。
+    implementation(libs.apache.sshd.common)
+    implementation(libs.apache.sshd.core)
+    implementation(libs.apache.sshd.sftp)
 
     // 🔥🔥🔥添加终端依赖
     implementation(project(":core:main"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,8 +22,12 @@ animation = "1.10.4"
 materialIconsExtended = "1.7.8"
 materialKolor = "4.1.1"
 navigationCompose = "2.9.7"
-orgEclipseJgit = "7.3.0.202506031305-r"
-orgEclipseJgitSshApache = "7.5.0.202512021534-r"
+orgEclipseJgit = "5.13.3.202401111512-r"
+orgEclipseJgitSshApache = "5.13.3.202401111512-r"
+# JGit 5.13.3 传递依赖 Apache MINA SSHD 2.7.0；该版本无 PathUtils.setUserHomeFolderResolver
+#（自 2.10.0 引入，用于在 Android 上重定向 SSH 用户主目录）。显式引入分离构件升级到 2.10.0，
+# 并排除 sshd-osgi fat bundle（其与 core/common 重复）。
+apacheSshd = "2.10.0"
 orgEclipseLsp4j = "0.24.0"
 treeSitterJson = "4.3.2"
 ui = "1.10.4"
@@ -113,6 +117,10 @@ gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 lsp4j = { module = "org.eclipse.lsp4j:org.eclipse.lsp4j", version.ref = "orgEclipseLsp4j" }
 org-eclipse-jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "orgEclipseJgit" }
 org-eclipse-jgit-ssh-apache = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache", version.ref = "orgEclipseJgitSshApache" }
+apache-sshd-common = { group = "org.apache.sshd", name = "sshd-common", version.ref = "apacheSshd" }
+apache-sshd-core = { group = "org.apache.sshd", name = "sshd-core", version.ref = "apacheSshd" }
+# sshd-osgi 是 fat bundle，Android 上排除不用（见 app/build.gradle.kts 的 exclude）
+apache-sshd-sftp = { group = "org.apache.sshd", name = "sshd-sftp", version.ref = "apacheSshd" }
 tree-sitter-json = { module = "com.itsaky.androidide.treesitter:tree-sitter-json", version.ref = "treeSitterJson" }
 zipalign-java = { module = "com.github.iyxan23:zipalign-java", version.ref = "zipalignJava" }
 volley = { group = "com.android.volley", name = "volley", version.ref = "volley" }


### PR DESCRIPTION
- JGit 7.x 调用 Java 9 的 readNBytes，Android <13 无此方法导致 NoSuchMethodError
- 降级 JGit core + ssh.apache 到 5.13.3（Java 8 基线）
- 显式引入 SSHD 2.10.0 分离构件，提供 setUserHomeFolderResolver
- 排除 sshd-osgi fat bundle 避免重复类
- 排除根目录 plugin.properties 避免资源冲突