### PR TITLE
fix(storage): 修复 Android 10 有存储权限但无法读取/切换工作目录到内部存储

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,6 +60,7 @@
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
     <application
         android:allowBackup="true"
+        android:requestLegacyExternalStorage="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/web/webide/ui/components/DirectorySelector.kt
+++ b/app/src/main/java/com/web/webide/ui/components/DirectorySelector.kt
@@ -62,6 +62,19 @@ fun DirectorySelector(
     var currentPath by remember { mutableStateOf(initialPath.ifEmpty { rootPath }) }
     var showCreateFolderDialog by remember { mutableStateOf(false) }
     val listState = rememberLazyListState()
+    // 权限可能在外部（系统设置页）授予，从设置返回时 Activity 会 ON_RESUME。
+    // 递增 refreshKey 让下方 directoryList 重新读取目录，避免“授权后列表仍为空、需重启 app”的问题。
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    var refreshKey by remember { mutableStateOf(0) }
+    DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                refreshKey++
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
     rememberCoroutineScope()
     val selectorTitle = stringResource(R.string.directory_selector_title)
     val newFolderDescription = stringResource(R.string.content_desc_new_folder)
@@ -72,7 +85,7 @@ fun DirectorySelector(
     val cancelText = stringResource(R.string.action_cancel)
     val selectThisText = stringResource(R.string.directory_select_this)
 
-    val directoryList by remember(currentPath) {
+    val directoryList by remember(currentPath, refreshKey) {
         derivedStateOf {
             try {
                 val currentDir = File(currentPath)


### PR DESCRIPTION
Fixes #14

## 问题
Android 10 设备获得存储权限后，目录选择器无法读取内部存储内容，
无法切换工作目录到内部存储下；权限授权后需重启应用才能生效。

## 根因
1. Manifest 未声明 requestLegacyExternalStorage=true。targetSdk=36 下 Android 10 默认启用分区存储，READ_EXTERNAL_STORAGE 仅对媒体文件有效， File API 读取 /storage/emulated/0 下的非媒体目录会失败。
2. DirectorySelector 的目录列表只依赖 currentPath，权限授予后 currentPath 不变，列表不重新计算，导致授权后需重启应用。

## 修复
- Manifest 添加 requestLegacyExternalStorage=true：让 Android 10 退回 legacy 存储模型（官方文档明确该属性在 Android 10 设备上即使 targetSdk>=30 仍有效，仅 Android 11+ 设备才忽略）。
- DirectorySelector 添加 Lifecycle ON_RESUME 监听：从权限设置返回时递增 refreshKey 触发目录列表重新 listFiles()，无需重启应用。

## 测试注意
requestLegacyExternalStorage 在应用安装时确定存储模型，必须完全卸载后重装 才生效，覆盖安装/OTA 升级不会切换已安装应用的存储模型。