### PR TITLE
fix(editor): 修复运行后代码被吞并优化大文件高亮卡顿

### DIFF
--- a/app/src/main/java/com/web/webide/ui/editor/components/CodeEditorView.kt
+++ b/app/src/main/java/com/web/webide/ui/editor/components/CodeEditorView.kt
@@ -343,21 +343,14 @@ fun CodeEditorView(
                     view.nonPrintablePaintingFlags = 0
                 }
 
-                if (view.text.toString() != state.content) {
-                    val cursor = view.cursor
-                    val cursorLine = cursor.leftLine
-                    val cursorColumn = cursor.leftColumn
-                    view.setText(state.content)
-                    try {
-                        val lineCount = view.text.lineCount
-                        val targetLine = cursorLine.coerceIn(0, lineCount - 1)
-                        val lineLength = if (targetLine < view.text.lineCount) view.text.getColumnCount(targetLine) else 0
-                        val targetColumn = cursorColumn.coerceIn(0, lineLength)
-                        view.setSelection(targetLine, targetColumn)
-                    } catch (e: Exception) {
-                        e.printStackTrace()
-                    }
-                }
+                // ⚠️ 不在此处用 setText(state.content) 回填编辑器（对应参考实现 §5.1 / §5.3）。
+                // 编辑器组件自身才是内容与 undo/redo 历史的权威来源：
+                //  - 用户输入经 ContentListener → onContentChanged 同步到 state.content；
+                //  - 外部改动（Diff / 配置保存）经 onContentChanged 的实例同步分支推送给编辑器；
+                //  - 从运行/预览页返回时编辑器实例未被销毁，文本与撤销栈完整保留。
+                // 若在此 setText，一旦 state.content 偶发落后于编辑器（如输入法批量编辑
+                // 漏触发监听），就会把用户“上一秒写的代码”覆盖回去 —— 即“代码被吞”。
+                // 因此重组 / 返回时绝不触碰编辑器内容与历史。
                 view.isEnabled = true
                 view.visibility = android.view.View.VISIBLE
                 view.requestLayout()

--- a/app/src/main/java/com/web/webide/ui/editor/viewmodel/EditorViewModel.kt
+++ b/app/src/main/java/com/web/webide/ui/editor/viewmodel/EditorViewModel.kt
@@ -492,9 +492,10 @@ class EditorViewModel(application: Application) : AndroidViewModel(application) 
                 "yaml", "yml" -> "source.yaml"
                 else -> return null
             }
-            val prefs = context.getSharedPreferences("WebIDE_Editor_Settings", Context.MODE_PRIVATE)
-            val lspEnabled = prefs.getBoolean("editor_lsp_enabled", false)
-            TextMateLanguage.create(scopeName, !lspEnabled)
+            // interruptionEnabled 始终为 true：TextMate 词法化是从文件头顺序扫描的正则状态机，
+            // 大文件首屏 tokenize 耗时较长。开启中断后 sora 会分片计算、及时让出主线程，
+            // 避免切换文件时 UI 卡顿（token 仍会全部完成，不影响正确性与 LSP）。
+            TextMateLanguage.create(scopeName, true)
         } catch (_: Exception) { null }
     }
 
@@ -543,7 +544,32 @@ class EditorViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
+    /**
+     * 以编辑器组件的实时文本刷新 [state.content]。
+     *
+     * 对应参考实现 `save()` 中 `code_code1.getText().toString()` 的做法：保存前始终
+     * 从编辑器现场读取最新内容。这样即便 ContentListener 偶发漏触发（使 state.content
+     * 落后于编辑器），也不会把用户“上一秒写的代码”当成旧内容写丢，彻底避免“代码被吞”。
+     *
+     * 该方法只读取编辑器、不修改编辑器，因此不会影响 undo/redo 栈。须在主线程调用。
+     */
+    fun flushEditorContent(state: CodeEditorState) {
+        val editor = editorInstances[state.file.absolutePath] ?: return
+        try {
+            val live = editor.text.toString()
+            if (live != state.content) {
+                state.content = live
+            }
+        } catch (_: Exception) { }
+    }
+
     suspend fun saveAllModifiedFiles(context: Context, snackbarHostState: SnackbarHostState): Boolean {
+        // 保存前先在主线程以编辑器实时内容刷新 state.content，避免写入陈旧内容
+        withContext(Dispatchers.Main) {
+            openFiles.filterIsInstance<CodeEditorState>()
+                .filter { it.isModified }
+                .forEach { flushEditorContent(it) }
+        }
         return withContext(Dispatchers.IO) {
             val modifiedFiles = openFiles.filterIsInstance<CodeEditorState>().filter { it.isModified }
             if (modifiedFiles.isEmpty()) return@withContext true
@@ -683,6 +709,12 @@ class EditorViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     suspend fun autoSaveProject(context: Context, projectPath: String) {
+        // 先在主线程以编辑器实时内容刷新 state.content（同 saveAllModifiedFiles）
+        withContext(Dispatchers.Main) {
+            openFiles.filterIsInstance<CodeEditorState>()
+                .filter { it.isModified }
+                .forEach { flushEditorContent(it) }
+        }
         withContext(Dispatchers.IO) {
             val modifiedFiles = openFiles.filterIsInstance<CodeEditorState>().filter { it.isModified }
             if (modifiedFiles.isNotEmpty()) {


### PR DESCRIPTION
## #18 运行后代码被吞
- 保存前以编辑器实时文本刷新 state.content（对应参考实现 save() 取 getText()）
- 移除 CodeEditorView 重组时的 setText 回填，编辑器作为内容/撤销栈权威来源

## #19 大文件高亮卡顿
- TextMate interruptionEnabled 始终为 true，分片计算避免同步阻塞主线程

Closes #18
Closes #19