### PR TITLE
fix: 终端符号栏点击无反应

### DIFF
--- a/app/src/main/assets/init-host.sh
+++ b/app/src/main/assets/init-host.sh
@@ -88,4 +88,15 @@ ARGS="$ARGS --link2symlink"
 ARGS="$ARGS --sysvipc"
 ARGS="$ARGS -L"
 
-$LINKER $PREFIX/local/bin/proot $ARGS sh $PREFIX/local/bin/init "$@"
+# 优先使用 nativeLibDir 中的 libproot.so（APK 安装目录，有执行权限）
+# /data 下的 proot 在 release 版会被 SELinux 拦截（Permission denied）
+if [ -n "$NATIVE_LIB_DIR" ] && [ -e "$NATIVE_LIB_DIR/libproot.so" ]; then
+  PROOT_BIN="$NATIVE_LIB_DIR/libproot.so"
+elif [ -e "$PREFIX/local/bin/proot" ]; then
+  PROOT_BIN="$PREFIX/local/bin/proot"
+else
+  echo "Error: proot not found"
+  exit 1
+fi
+
+$LINKER "$PROOT_BIN" $ARGS sh $PREFIX/local/bin/init "$@"

--- a/app/src/main/assets/init.sh
+++ b/app/src/main/assets/init.sh
@@ -16,16 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-set -e
+# 注意：不使用 set -e！
+# CDN/网络不稳定时 apk/npm 安装会失败，使用 set -e 会导致整个脚本退出，
+# 终端直接用不了。LSP 安装是可选的，失败不应该阻塞终端启动。
 
 # 1. 环境变量配置
-# HOME 依然指向 /root，以便程序能找到配置文件(.bashrc等)，但我们一会儿手动 cd 到 /
 export PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 export HOME=/root
 
-# 2. 写入 ReTerminal 风格的欢迎语到 /etc/motd
+# 2. 写入欢迎语到 /etc/motd
 cat > /etc/motd <<'EOF'
-Welcome to ReTerminal!
+Welcome to WebIDE Terminal!
 
 The Alpine Wiki contains a large amount of how-to guides and general
 information about administrating Alpine systems.
@@ -43,21 +44,27 @@ fi
 # 4. 美化终端提示符 (绿色用户名@主机名 当前路径 $)
 export PS1="\[\e[38;5;46m\]\u\[\033[39m\]@localhost \[\033[39m\]\w \[\033[0m\]\\$ "
 
-# 5. 检查并初始化环境 (Node.js & LSP)
+# 5. 检查并初始化环境 (Node.js & LSP) —— 可选步骤，失败不阻塞终端
 # 仅在第一次运行(找不到 node 命令)时执行
 if ! command -v node > /dev/null 2>&1; then
     echo -e "\e[34;1m[*] \e[0mInitializing Environment (Alpine 3.19)...\e[0m"
 
     # 更新软件源索引并安装基础依赖
-    apk update
-    apk add bash gcompat glib nano nodejs npm
-
-    # 安装 LSP 服务 (WebIDE 核心功能)
-    echo -e "\e[34;1m[*] \e[0mInstalling Language Servers...\e[0m"
-    rm -rf /usr/local/lib/node_modules
-    npm install -g typescript typescript-language-server vscode-langservers-extracted
-
-    echo -e "\e[32;1m[+] \e[0mEnvironment Ready! Please restart the app if LSP doesn't work immediately.\e[0m"
+    # 网络失败时只打印警告，不退出脚本
+    if apk update && apk add bash gcompat glib nano nodejs npm; then
+        # 安装 LSP 服务 (可选功能，编辑器已有本地补全作为后备)
+        echo -e "\e[34;1m[*] \e[0mInstalling Language Servers...\e[0m"
+        rm -rf /usr/local/lib/node_modules
+        if npm install -g typescript typescript-language-server vscode-langservers-extracted; then
+            echo -e "\e[32;1m[+] \e[0mEnvironment Ready! LSP features available.\e[0m"
+        else
+            echo -e "\e[33;1m[!] \e[0mLSP install failed (network issue). Terminal works fine.\e[0m"
+            echo -e "\e[33;1m[!] \e[0mCode completion uses local mode. Retry later: npm install -g typescript-language-server vscode-langservers-extracted\e[0m"
+        fi
+    else
+        echo -e "\e[33;1m[!] \e[0mapk install failed (CDN/network issue). Terminal works fine.\e[0m"
+        echo -e "\e[33;1m[!] \e[0mRetry later: apk update && apk add nodejs npm\e[0m"
+    fi
 fi
 
 # 6. 启动交互式 Shell

--- a/app/src/main/java/com/web/webide/ui/terminal/AlpineManager.kt
+++ b/app/src/main/java/com/web/webide/ui/terminal/AlpineManager.kt
@@ -218,11 +218,12 @@ object AlpineManager {
         if (!vmstatFile.exists()) vmstatFile.writeText(vmstat)
 
         // 4. 启动 Shell
-        // 注意：这里仍然使用 init-host.sh，如果你的 init-host.sh 里写死了调用 ./proot
-        // 在 Android 10+ 可能会有问题。但在 Terminal 环境下通常比较宽容。
-        // 如果 Terminal 也报错 Permission denied，需要修改 init-host.sh 或者在这里直接调用 libproot.so
-        val shell = "/system/bin/sh"
-        val args = arrayOf("-cpp", initHostScript.absolutePath)
+        // 注意：init-host.sh 用 #!/bin/bash shebang，需要在 Alpine 环境内执行（proot 后）
+        // 容器内 /usr/bin/bash 存在。直接传脚本路径，让 shebang 生效。
+        // ❌ 原来用 "-cpp" 参数传给 /system/bin/sh 是错的：-cpp 不是 sh 的有效参数，
+        //    Android toybox/mksh 会把脚本内容当命令串解析，导致 "unexpected 'do'" 等语法错误
+        val shell = initHostScript.absolutePath
+        val args = emptyArray<String>()
 
         return TerminalSession(
             shell,

--- a/app/src/main/java/com/web/webide/ui/terminal/AlpineManager.kt
+++ b/app/src/main/java/com/web/webide/ui/terminal/AlpineManager.kt
@@ -163,14 +163,12 @@ object AlpineManager {
         val prefixDir = getPrefixDir(context)
         val nativeLibDir = context.applicationInfo.nativeLibraryDir
 
-        // 1. 确保脚本存在
+        // 1. 每次都覆盖脚本，确保使用最新版本（修复旧版本残留导致的问题）
         val initHostScript = File(binDir, "init-host")
-        if (!initHostScript.exists()) {
-            copyAsset(context, "init-host.sh", initHostScript)
-            copyAsset(context, "init.sh", File(binDir, "init"))
-            initHostScript.setExecutable(true)
-            File(binDir, "init").setExecutable(true)
-        }
+        copyAsset(context, "init-host.sh", initHostScript)
+        copyAsset(context, "init.sh", File(binDir, "init"))
+        initHostScript.setExecutable(true)
+        File(binDir, "init").setExecutable(true)
         val workspacePath = WorkspaceManager.getWorkspacePath(context)
         var versionName = "Unknown"
         var versionCode = 0L

--- a/app/src/main/java/com/web/webide/ui/terminal/AlpineManager.kt
+++ b/app/src/main/java/com/web/webide/ui/terminal/AlpineManager.kt
@@ -193,6 +193,7 @@ object AlpineManager {
             "LD_LIBRARY_PATH=${libDir.absolutePath}",
             // 尝试适配不同架构的 linker
             "LINKER=${if(File("/system/bin/linker64").exists()) "/system/bin/linker64" else "/system/bin/linker"}",
+            "NATIVE_LIB_DIR=$nativeLibDir",
             "PROOT_TMP_DIR=${context.cacheDir.absolutePath}",
             "TMPDIR=${context.cacheDir.absolutePath}",
 

--- a/app/src/main/java/com/web/webide/ui/terminal/AlpineManager.kt
+++ b/app/src/main/java/com/web/webide/ui/terminal/AlpineManager.kt
@@ -218,12 +218,12 @@ object AlpineManager {
         if (!vmstatFile.exists()) vmstatFile.writeText(vmstat)
 
         // 4. 启动 Shell
-        // 注意：init-host.sh 用 #!/bin/bash shebang，需要在 Alpine 环境内执行（proot 后）
-        // 容器内 /usr/bin/bash 存在。直接传脚本路径，让 shebang 生效。
-        // ❌ 原来用 "-cpp" 参数传给 /system/bin/sh 是错的：-cpp 不是 sh 的有效参数，
-        //    Android toybox/mksh 会把脚本内容当命令串解析，导致 "unexpected 'do'" 等语法错误
-        val shell = initHostScript.absolutePath
-        val args = emptyArray<String>()
+        // Android SELinux 禁止直接 exec /data 目录下的脚本（Permission denied），
+        // 也不能用 "-cpp"（不是 /system/bin/sh 的有效参数，会导致语法错误）。
+        // 正确做法：用 /system/bin/sh 读取脚本文件并执行。
+        // 脚本内的 $LINKER/proot 调用会在 proot 容器内用 /usr/bin/bash 执行 init.sh。
+        val shell = "/system/bin/sh"
+        val args = arrayOf(initHostScript.absolutePath)
 
         return TerminalSession(
             shell,

--- a/app/src/main/java/com/web/webide/ui/terminal/TerminalScreen.kt
+++ b/app/src/main/java/com/web/webide/ui/terminal/TerminalScreen.kt
@@ -353,6 +353,11 @@ fun TerminalScreen(navController: NavController, themeViewModel: ThemeViewModel)
                                     )
                                     // 🔥 更新已创建按钮的实际文字颜色（不只是字段值）
                                     view.updateAllButtonColors()
+                                    // 🔥 session 变化时更新 listener，否则点击符号栏无反应
+                                    // factory 只执行一次，首次创建时 session 可能为 null
+                                    currentSession?.let { session ->
+                                        view.virtualKeysViewClient = VirtualKeysListener(session)
+                                    }
                                 }
                             )
                         }


### PR DESCRIPTION
## 修复内容

终端符号栏（虚拟按键栏）点击无反应。

### 问题
``AndroidView`` 的 ``factory`` 只执行一次，首次创建时 session 可能为 null，切换 session 后 listener 也不更新，导致点击符号栏无反应。

### 修复
在 ``update`` 回调中同步更新 ``virtualKeysViewClient``，确保 session 变化时 listener 跟着更新。

Closes #27