### PR TITLE
fix(lsp): 修复 LSP 环境概率性失效与补全文字暗色模式不可见 (v0.3.8)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,8 +35,8 @@ android {
         minSdk = 29
         //noinspection OldTargetApi
         targetSdk = 36
-        versionCode = 37
-        versionName = "0.3.7"
+        versionCode = 38
+        versionName = "0.3.8"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // 编译时间戳：每次构建时写入当前毫秒时间，供“关于”页展示构建时间。

--- a/app/src/main/java/com/web/webide/ui/editor/EditorColorSchemeManager.kt
+++ b/app/src/main/java/com/web/webide/ui/editor/EditorColorSchemeManager.kt
@@ -37,6 +37,12 @@ object EditorColorSchemeManager {
         val background = colorScheme.background.toArgb()
         val onSurfaceVariant = colorScheme.onSurfaceVariant.toArgb()
 
+        // 明暗判断必须基于 Material 主题色（colorScheme.background），它总是可靠地反映
+        // 应用当前的实际明暗模式。不能用 editor scheme 的 WHOLE_BACKGROUND：当编辑器使用
+        // TextMateColorScheme 时，getColor(WHOLE_BACKGROUND) 会被覆盖为 TextMate 主题计算值，
+        // 而 TextMate 主题是异步应用的，此时可能仍是浅色，导致误判为亮色、补全文字仍为黑色。
+        val isDark = isColorDark(background)
+
         scheme.apply {
             // 只更新基础背景和文本颜色
             setColor(EditorColorScheme.WHOLE_BACKGROUND, background)
@@ -44,57 +50,57 @@ object EditorColorSchemeManager {
             setColor(EditorColorScheme.LINE_DIVIDER, surfaceVariant)
             setColor(EditorColorScheme.LINE_NUMBER, onSurfaceVariant)
             setColor(EditorColorScheme.LINE_NUMBER_CURRENT, primary)
-            
+
             // 当前行高亮
             setColor(EditorColorScheme.CURRENT_LINE, adjustAlpha(surfaceVariant, 0.3f))
-            
+
             // 选择相关
             setColor(EditorColorScheme.SELECTED_TEXT_BACKGROUND, adjustAlpha(primary, 0.25f))
             setColor(EditorColorScheme.SELECTION_INSERT, primary)
             setColor(EditorColorScheme.SELECTION_HANDLE, primary)
-            
+
             // 滚动条
             setColor(EditorColorScheme.SCROLL_BAR_THUMB, adjustAlpha(onSurfaceVariant, 0.3f))
             setColor(EditorColorScheme.SCROLL_BAR_THUMB_PRESSED, adjustAlpha(primary, 0.5f))
-            
+
             // 自动完成窗口
             setColor(EditorColorScheme.COMPLETION_WND_BACKGROUND, surface)
             setColor(EditorColorScheme.COMPLETION_WND_CORNER, surfaceVariant)
             setColor(EditorColorScheme.COMPLETION_WND_ITEM_CURRENT, adjustAlpha(primary, 0.2f))
             // 补全窗口文字颜色：sora 默认依赖 isDark()（恒为 false）导致暗色下显示黑字看不清。
-            // 这里显式覆盖：暗色模式用纯白，亮色模式跟随主题前景色。
-            if (isDarkScheme(this)) {
+            // 用 Material 主题的明暗判断显式覆盖：暗色模式用纯白，亮色模式跟随主题前景色。
+            if (isDark) {
                 setColor(EditorColorScheme.COMPLETION_WND_TEXT_PRIMARY, AndroidColor.WHITE)
                 setColor(EditorColorScheme.COMPLETION_WND_TEXT_SECONDARY, 0xFFB0B0B0.toInt())
             } else {
                 setColor(EditorColorScheme.COMPLETION_WND_TEXT_PRIMARY, colorScheme.onSurface.toArgb())
                 setColor(EditorColorScheme.COMPLETION_WND_TEXT_SECONDARY, onSurfaceVariant)
             }
-            
+
             // 文本操作弹窗 (双击/长按弹出的菜单)
             setColor(EditorColorScheme.TEXT_ACTION_WINDOW_BACKGROUND, surface)
             setColor(EditorColorScheme.TEXT_ACTION_WINDOW_ICON_COLOR, primary)
-            
+
             // 括号匹配
             setColor(EditorColorScheme.HIGHLIGHTED_DELIMITERS_FOREGROUND, primary)
             setColor(EditorColorScheme.HIGHLIGHTED_DELIMITERS_BACKGROUND, AndroidColor.TRANSPARENT)
             setColor(EditorColorScheme.HIGHLIGHTED_DELIMITERS_BORDER, AndroidColor.TRANSPARENT)
             setColor(EditorColorScheme.HIGHLIGHTED_DELIMITERS_UNDERLINE, primary)
-            
+
             // 下划线
             setColor(EditorColorScheme.UNDERLINE, primary)
-            
+
             // 代码块线条
             setColor(EditorColorScheme.BLOCK_LINE, surfaceVariant)
             setColor(EditorColorScheme.BLOCK_LINE_CURRENT, primary)
             setColor(EditorColorScheme.SIDE_BLOCK_LINE, surfaceVariant)
-            
+
             // 确保文本颜色适配深色/浅色模式 (针对 TreeSitter 或默认编辑器)
             val onBackground = colorScheme.onBackground.toArgb()
             setColor(EditorColorScheme.TEXT_NORMAL, onBackground)
-            
+
             // 如果是浅色模式，优化 TreeSitter 的默认高亮颜色 (简单的覆盖，防止看不清)
-            if (!isDarkScheme(this)) {
+            if (!isDark) {
                  setColor(EditorColorScheme.KEYWORD, 0xFF0000FF.toInt()) // 蓝色关键字
                  setColor(EditorColorScheme.COMMENT, 0xFF008000.toInt()) // 绿色注释
                  setColor(EditorColorScheme.LITERAL, 0xFF098658.toInt()) // 深绿数字/常量
@@ -107,6 +113,13 @@ object EditorColorSchemeManager {
                  setColor(EditorColorScheme.HTML_TAG, 0xFF800000.toInt()) // HTML标签
             }
         }
+    }
+
+    private fun isColorDark(color: Int): Boolean {
+        val r = AndroidColor.red(color)
+        val g = AndroidColor.green(color)
+        val b = AndroidColor.blue(color)
+        return (r * 0.299 + g * 0.587 + b * 0.114) < 128
     }
 
     private fun adjustAlpha(color: Int, alpha: Float): Int {

--- a/app/src/main/java/com/web/webide/ui/editor/viewmodel/EditorViewModel.kt
+++ b/app/src/main/java/com/web/webide/ui/editor/viewmodel/EditorViewModel.kt
@@ -37,6 +37,7 @@ import com.web.webide.core.utils.PermissionManager
 import com.web.webide.ui.editor.EditorColorSchemeManager
 import com.web.webide.ui.editor.TextMateInitializer
 import com.web.webide.ui.editor.git.GitManager
+import com.web.webide.ui.terminal.SetupWorker
 import io.github.rosemoe.sora.lang.Language
 import io.github.rosemoe.sora.lang.EmptyLanguage
 import io.github.rosemoe.sora.lang.styling.TextStyle
@@ -989,7 +990,20 @@ class EditorViewModel(application: Application) : AndroidViewModel(application) 
                 }
             })
 
-            viewModelScope.launch(Dispatchers.IO) { try { lspEditor.connect() } catch (_: Exception){} }
+            viewModelScope.launch(Dispatchers.IO) {
+                try {
+                    // rootfs 完整时直接连 LSP（瞬时，不阻塞）；不完整才重新解压修复。
+                    // 避免每次启动 LSP 都等 30-90s 解压。
+                    if (!SetupWorker.isEnvironmentReady(context)) {
+                        android.util.Log.w("LSP-Setup", "rootfs 不完整，开始重新解压...")
+                        SetupWorker.prepareEnvironment(context)
+                        android.util.Log.i("LSP-Setup", "rootfs 修复完成，连接 LSP")
+                    }
+                    lspEditor.connect()
+                } catch (e: Exception) {
+                    android.util.Log.e("LSP-Setup", "LSP 连接失败", e)
+                }
+            }
         } catch (e: Exception) { e.printStackTrace() }
     }
 

--- a/app/src/main/java/com/web/webide/ui/terminal/SetupWorker.kt
+++ b/app/src/main/java/com/web/webide/ui/terminal/SetupWorker.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
@@ -56,6 +58,10 @@ object SetupWorker {
 
     private var startTimestamp: Long = 0L
 
+    // 互斥锁：终端和 LSP 启动路径都可能调用 prepareEnvironment，用锁保证串行，
+    // 避免并发解压/删目录导致的文件错乱。
+    private val mutex = Mutex()
+
     sealed class PrepareResult {
         object Success : PrepareResult()
         object Timeout : PrepareResult()
@@ -65,11 +71,12 @@ object SetupWorker {
     /**
      * 准备终端环境，最多等待 [timeoutMs] 毫秒。
      * 超时或出错都不抛异常，返回结果让 UI 决定怎么提示。
+     * 内部用 Mutex 保证并发安全（终端与 LSP 路径可能同时调用）。
      */
     suspend fun prepareEnvironment(
         context: Context,
         timeoutMs: Long = 180_000L
-    ): PrepareResult {
+    ): PrepareResult = mutex.withLock {
         startTimestamp = System.currentTimeMillis()
         emit(Progress.Phase.COPYING_PROOT)
         val result = withTimeoutOrNull(timeoutMs) {
@@ -77,7 +84,7 @@ object SetupWorker {
                 doPrepare(context)
             }
         }
-        return result ?: PrepareResult.Timeout.also {
+        result ?: PrepareResult.Timeout.also {
             emit(Progress.Phase.TIMEOUT, elapsedMs = elapsed())
         }
     }
@@ -125,14 +132,35 @@ object SetupWorker {
 
     /**
      * 校验 Alpine rootfs 是否解压完整。
-     * 关键可执行文件全部存在即认为完整，避免解压中断后 etc 已生成但 /usr/bin/env 缺失，
-     * 导致 proot 执行 `/usr/bin/env <语言服务器>` 时报 not found。
+     *
+     * 只检查真实文件 bin/busybox 是否存在，不检查符号链接（usr/bin/env、bin/sh）。
+     * 原因：Alpine 里 env/sh 是指向 busybox 的符号链接，File.exists() 会跟随符号链接
+     * 解析目标。在宿主 Android 上，符号链接的目标路径解析与 proot 容器内不同
+     * （proot 用 -r 做路径翻译，宿主不会），导致符号链接在宿主上"断链"误判为不存在，
+     * 进而触发反复重新解压、死循环。proot 运行时能正确解析这些符号链接，所以只要
+     * busybox 这个真实文件在，rootfs 就是完整的。
      */
     private fun isRootfsComplete(alpineDir: File): Boolean {
-        if (!alpineDir.exists()) return false
-        return File(alpineDir, "usr/bin/env").exists() &&
-               File(alpineDir, "bin/busybox").exists() &&
-               File(alpineDir, "bin/sh").exists()
+        if (!alpineDir.exists()) {
+            android.util.Log.w("LSP-Setup", "rootfs 目录不存在: ${alpineDir.absolutePath}")
+            return false
+        }
+        val busyboxFile = File(alpineDir, "bin/busybox")
+        val ok = busyboxFile.exists()
+        if (!ok) {
+            android.util.Log.w("LSP-Setup", "rootfs 不完整: busybox 不存在, dir=${alpineDir.list()?.joinToString(",") ?: "(empty)"}")
+        }
+        return ok
+    }
+
+    /**
+     * 公开的快速环境检查（仅做文件存在性校验，不解压、不阻塞）。
+     * LSP 启动路径用它判断 rootfs 是否就绪：就绪则直接连 LSP，不就绪才走 prepareEnvironment。
+     */
+    fun isEnvironmentReady(context: Context): Boolean {
+        val prefixDir = context.filesDir.parentFile!!
+        val alpineDir = File(prefixDir, "local/alpine")
+        return isRootfsComplete(alpineDir)
     }
 
     private fun doPrepare(context: Context): PrepareResult {
@@ -156,33 +184,70 @@ object SetupWorker {
             // 启动语言服务器时报 '/usr/bin/env' not found 并陷入重启死循环，表现为
             // LSP 代码补全完全失效、编辑器被拖卡。这里改为校验关键文件完整性。
             val rootfsTar = File(filesDir, "alpine.tar.gz")
-            if (!rootfsTar.exists()) {
-                emit(Progress.Phase.EXTRACTING_ROOTFS, 0)
-                copyAsset(context, "rootfs.bin", rootfsTar)
-            }
-
             if (!isRootfsComplete(alpineDir)) {
                 // 解压不完整（首次安装或上次被中断）：清理残留后重新解压，避免文件错乱
                 if (alpineDir.exists()) {
                     alpineDir.deleteRecursively()
                 }
                 alpineDir.mkdirs()
-                // 启动进度监控线程
-                val monitor = startExtractProgressMonitor(rootfsTar.length(), alpineDir)
-                monitor.start()
-                try {
-                    val cmd = "tar -zxf ${rootfsTar.absolutePath} -C ${alpineDir.absolutePath}"
-                    val process = Runtime.getRuntime().exec(cmd)
-                    process.waitFor()
-                    if (process.exitValue() != 0) {
-                        Runtime.getRuntime()
-                            .exec("tar -xf ${rootfsTar.absolutePath} -C ${alpineDir.absolutePath}")
-                            .waitFor()
+
+                // 重试机制：rootfs 仅 40MB，但拷贝/解压可能因进程被系统内存压力杀掉、
+                // 或 alpine.tar.gz 上次拷贝被中断导致残缺而失败（表现为概率性解压失败）。
+                // 每次重试都重新从 assets 拷贝压缩包，确保源头完整；解压后校验关键文件，
+                // 不通过则重试，最多 3 次。避免“解压没完成却报成功”导致 LSP 起不来。
+                var extracted = false
+                for (attempt in 1..3) {
+                    // 首次尝试：若已有 alpine.tar.gz 则复用（可能只是解压被中断，包本身完整）；
+                    // 后续重试：强制重新拷贝（旧包可能在上次中断时损坏）
+                    if (attempt == 1) {
+                        if (!rootfsTar.exists() || rootfsTar.length() == 0L) {
+                            emit(Progress.Phase.EXTRACTING_ROOTFS, 0)
+                            copyAsset(context, "rootfs.bin", rootfsTar)
+                        }
+                    } else {
+                        rootfsTar.delete()
+                        emit(Progress.Phase.EXTRACTING_ROOTFS, 0)
+                        copyAsset(context, "rootfs.bin", rootfsTar)
                     }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                } finally {
-                    monitor.interrupt()
+                    if (!rootfsTar.exists() || rootfsTar.length() == 0L) {
+                        // 拷贝失败，直接进入下一轮重试
+                        continue
+                    }
+
+                    // 启动进度监控线程
+                    val monitor = startExtractProgressMonitor(rootfsTar.length(), alpineDir)
+                    monitor.start()
+                    try {
+                        val cmd = "tar -zxf ${rootfsTar.absolutePath} -C ${alpineDir.absolutePath}"
+                        val process = Runtime.getRuntime().exec(cmd)
+                        process.waitFor()
+                        if (process.exitValue() != 0) {
+                            // 兜底：gz 解压失败再尝试不带 -z 的纯 tar
+                            Runtime.getRuntime()
+                                .exec("tar -xf ${rootfsTar.absolutePath} -C ${alpineDir.absolutePath}")
+                                .waitFor()
+                        }
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    } finally {
+                        monitor.interrupt()
+                    }
+
+                    if (isRootfsComplete(alpineDir)) {
+                        extracted = true
+                        break
+                    }
+                    // 解压仍不完整：清理残留，下一轮重新拷贝 + 解压
+                    if (alpineDir.exists()) {
+                        alpineDir.deleteRecursively()
+                    }
+                    alpineDir.mkdirs()
+                }
+
+                if (!extracted) {
+                    // 解压确实失败：如实上报错误，而不是误报成功让 LSP 在残缺环境里起不来
+                    emit(Progress.Phase.ERROR, elapsedMs = elapsed())
+                    return PrepareResult.Error("rootfs 解压失败，请重试")
                 }
             }
 

--- a/app/src/main/java/com/web/webide/ui/terminal/TerminalScreen.kt
+++ b/app/src/main/java/com/web/webide/ui/terminal/TerminalScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -51,8 +50,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -106,9 +103,6 @@ import java.lang.ref.WeakReference
 @Composable
 fun TerminalScreen(navController: NavController, themeViewModel: ThemeViewModel) {
     val context = LocalContext.current
-    var isEnvironmentReady by remember { mutableStateOf(false) }
-    // null = 进行中，非空 = 已结束（成功/超时/出错）
-    var prepareStatus by remember { mutableStateOf<SetupWorker.PrepareResult?>(null) }
 
     // 🔥 终端配色必须跟随应用实际主题（用户可选跟随系统/强制浅色/强制深色），
     // 而不是直接用 isSystemInDarkTheme()，否则应用内强制深色时终端仍是浅色配色。
@@ -122,12 +116,11 @@ fun TerminalScreen(navController: NavController, themeViewModel: ThemeViewModel)
     }
 
     // === 初始化逻辑 ===
-    // 90 秒超时；超时/出错也允许进入终端（不阻塞用户）
+    // 环境准备在后台进行，不再用整屏 loading 阻塞界面。终端 UI 立即显示，
+    // 会话在准备完成后创建（首次解压需 30–90s，后续启动因 rootfs 已就绪而瞬时完成）。
     LaunchedEffect(Unit) {
         if (application == null) application = context.applicationContext as Application
-        val result = SetupWorker.prepareEnvironment(context, timeoutMs = 90_000L)
-        prepareStatus = result
-        isEnvironmentReady = true
+        SetupWorker.prepareEnvironment(context, timeoutMs = 90_000L)
         if (SessionManager.sessions.isEmpty()) {
             SessionManager.addNewSession(context)
         }
@@ -138,59 +131,6 @@ fun TerminalScreen(navController: NavController, themeViewModel: ThemeViewModel)
     // 而不是默认的黑底白字。
     LaunchedEffect(isDark) {
         TerminalConfig.applyColorScheme(isDark)
-    }
-
-    if (!isEnvironmentReady) {
-        // 🔥 loading 体验修复：显示当前阶段、百分比、已耗时
-        val progress by SetupWorker.progress.collectAsState()
-        val phaseText = when (progress.phase) {
-            SetupWorker.Progress.Phase.IDLE,
-            SetupWorker.Progress.Phase.COPYING_PROOT ->
-                stringResource(R.string.terminal_prepare_copying_proot)
-            SetupWorker.Progress.Phase.EXTRACTING_ROOTFS ->
-                stringResource(R.string.terminal_prepare_extracting_rootfs)
-            SetupWorker.Progress.Phase.FINALIZING ->
-                stringResource(R.string.terminal_prepare_finalizing)
-            SetupWorker.Progress.Phase.TIMEOUT ->
-                stringResource(R.string.terminal_prepare_timeout)
-            SetupWorker.Progress.Phase.ERROR ->
-                stringResource(R.string.terminal_prepare_error)
-            SetupWorker.Progress.Phase.SUCCESS ->
-                stringResource(R.string.terminal_preparing)
-        }
-        Box(
-            modifier = Modifier.fillMaxSize().padding(24.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                if (progress.phase == SetupWorker.Progress.Phase.TIMEOUT ||
-                    progress.phase == SetupWorker.Progress.Phase.ERROR
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Warning,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.error
-                    )
-                } else {
-                    val p = if (progress.percent in 0..100) progress.percent / 100f else 0f
-                    CircularProgressIndicator(progress = p)
-                }
-                Text(text = phaseText, style = MaterialTheme.typography.titleMedium)
-                if (progress.percent in 0..100) {
-                    Text(text = "${progress.percent}%", style = MaterialTheme.typography.bodyLarge)
-                }
-                val seconds = progress.elapsedMs / 1000
-                Text(
-                    text = stringResource(R.string.terminal_prepare_elapsed, seconds),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-        return
     }
 
     val currentSession = SessionManager.currentSession

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/component/DefaultCompletionItemAdapter.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/component/DefaultCompletionItemAdapter.java
@@ -53,13 +53,22 @@ public final class DefaultCompletionItemAdapter extends EditorCompletionAdapter 
         }
         var item = getItem(pos);
 
+        // 补全文字颜色根据补全窗口背景亮度自适应，不依赖 COMPLETION_WND_TEXT_PRIMARY。
+        // 当编辑器使用 TextMateColorScheme 时，其 onChangeTheme 回调会 colors.clear() 清空
+        // 我们 setColor 写入的值并重置为默认（暗色判断不准时为黑色），导致暗色下补全文字看不清。
+        // 直接按背景算颜色可彻底绕开该问题：暗色背景→白字，亮色背景→黑字。
+        int bgColor = getThemeColor(EditorColorScheme.COMPLETION_WND_BACKGROUND);
+        boolean dark = isColorDark(bgColor);
+        int primaryColor = dark ? 0xFFFFFFFF : 0xFF000000;
+        int secondaryColor = dark ? 0xFFB0B0B0 : 0xFF616161;
+
         TextView tv = view.findViewById(R.id.result_item_label);
         tv.setText(item.label);
-        tv.setTextColor(getThemeColor(EditorColorScheme.COMPLETION_WND_TEXT_PRIMARY));
+        tv.setTextColor(primaryColor);
 
         tv = view.findViewById(R.id.result_item_desc);
         tv.setText(item.desc);
-        tv.setTextColor(getThemeColor(EditorColorScheme.COMPLETION_WND_TEXT_SECONDARY));
+        tv.setTextColor(secondaryColor);
 
         view.setTag(pos);
         if (isCurrentCursorPosition) {
@@ -70,6 +79,13 @@ public final class DefaultCompletionItemAdapter extends EditorCompletionAdapter 
         ImageView iv = view.findViewById(R.id.result_item_image);
         iv.setImageDrawable(item.icon);
         return view;
+    }
+
+    private static boolean isColorDark(int color) {
+        int r = (color >> 16) & 0xFF;
+        int g = (color >> 8) & 0xFF;
+        int b = color & 0xFF;
+        return (r * 0.299 + g * 0.587 + b * 0.114) < 128;
     }
 
 }


### PR DESCRIPTION
## 修复内容

本次修复 LSP 环境可靠性问题，解决多次反馈的「概率性失效」「二次打开不能用」「暗色模式补全文字不可见」等问题。

### 1. LSP 启动死循环解压（根因修复）

**症状**：LSP 启动时反复触发解压，卡在 30-90s 循环，永远连不上。

**根因**：rootfs 完整性校验用 `File.exists()` 检查 `usr/bin/env`、`bin/sh` 等符号链接。Alpine 里这些是指向 busybox 的符号链接，在宿主 Android 上符号链接目标解析与 proot 容器内不同（proot 用 `-r` 做路径翻译），导致符号链接在宿主上被误判为断链 → 触发重新解压 → 解压后符号链接在宿主上仍被误判为断链 → 无限循环。

**修复**：`isRootfsComplete()` 只校验真实文件 `bin/busybox` 是否存在，不检查符号链接。busybox 在即认为 rootfs 完整，直接连 LSP。proot 运行时能正确解析这些符号链接，所以符号链接本身没坏。

### 2. LSP 启动前校验环境完整性

EditorViewModel 启动 LSP 前调用 `SetupWorker.isEnvironmentReady()` 快速校验（瞬时，<1ms）：
- **rootfs 完整**：直接连 LSP，不再被解压阻塞
- **rootfs 不完整**：重新解压修复后再连 LSP
- **从未解压过**：首次解压（30-90s），完成后自动连 LSP

解决「重启后 LSP 用不了」「从未进终端直接开编辑器没有 LSP」。

### 3. 补全文字暗色模式不可见

**症状**：暗色模式下 LSP 补全弹窗文字是黑色，几乎看不见。

**根因**：`EditorColorSchemeManager.setColor(COMPLETION_WND_TEXT_PRIMARY, 白色)` 无效，因为 `TextMateColorScheme` 注册了主题变更监听器，TextMate 主题异步加载完成时回调 `onChangeTheme` → `setTheme` → `super.colors.clear()` 清空所有颜色 → 写入的白色被冲掉。

**修复**：`DefaultCompletionItemAdapter` 改为根据补全窗口背景亮度实时计算文字颜色，不再读 `COMPLETION_WND_TEXT_PRIMARY`。暗色背景→白字，亮色背景→黑字，不再依赖任何会被异步清空的颜色项。

### 4. 附带改动

- 终端移除整屏 loading 阻塞，环境准备后台进行
- `SetupWorker` 解压增加完整性校验与重试机制（最多 3 次），解压失败如实返回 Error 不再误报 Success
- 解压中断后残缺压缩包会被强制重新拷贝

### 版本

版本号升级至 `0.3.8`（versionCode 38）。

## 测试验证

- 编译通过（`compileArm64-v8aDebugKotlin`）
- 实机日志验证 LSP 握手成功、completion/hover/highlight 请求正常往返
- 暗色模式补全文字显示为白色

## 改动文件

- `app/build.gradle.kts` — 版本号 0.3.8
- `app/.../EditorColorSchemeManager.kt` — 明暗判断改用 Material background
- `app/.../EditorViewModel.kt` — LSP 启动前校验 rootfs
- `app/.../SetupWorker.kt` — rootfs 校验只查 busybox，新增 isEnvironmentReady()
- `app/.../TerminalScreen.kt` — 移除整屏 loading
- `editor/.../DefaultCompletionItemAdapter.java` — 补全文字颜色按背景亮度计算
