### PR TITLE
feat(ui): 添加社区联系方式卡片到设置页面

### DIFF
--- a/app/src/main/java/com/web/webide/ui/settings/AboutScreen.kt
+++ b/app/src/main/java/com/web/webide/ui/settings/AboutScreen.kt
@@ -780,6 +780,96 @@ private fun AppInfoCard() {
 }
 
 @Composable
+private fun CommunityCard() {
+    val context = LocalContext.current
+    // 用 Column + clip + background 替代 Surface，避免外层 Surface 干扰点击事件
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        // QQ 群：整行点击跳转
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    runCatching {
+                        val intent = Intent(Intent.ACTION_VIEW, "https://qm.qq.com/q/tFXuqMQDlK".toUri())
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        context.startActivity(intent)
+                    }
+                }
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.about_community_qq_group),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = "1050254184",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+                fontFamily = FontFamily.Monospace,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(16.dp)
+            )
+        }
+        HorizontalDivider(
+            modifier = Modifier.padding(horizontal = 20.dp),
+            thickness = 0.5.dp,
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+        )
+        // Telegram 频道：整行点击跳转，布局与 QQ 群一致
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    runCatching {
+                        val intent = Intent(Intent.ACTION_VIEW, "https://t.me/Android_For_WebIDE".toUri())
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        context.startActivity(intent)
+                    }
+                }
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.about_community_tg_group),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = "@Android_For_WebIDE",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+                fontFamily = FontFamily.Monospace,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(16.dp)
+            )
+        }
+    }
+}
+@Composable
 private fun SectionTitle(text: String) {
     Text(
         text = text,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,6 @@
-# Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-# Specifies the JVM arguments used for the daemon process.
-
 #
 # WebIDE - A powerful IDE for Android web development.
-# Copyright (C) 2025  ????  <3382198490@qq.com>
+# Copyright (C) 2025  如日中天  <3382198490@qq.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,7 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-# The setting is particularly useful for tweaking memory settings.
+
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
@@ -45,3 +45,5 @@ android.nonTransitiveRClass=false
 # org.gradle.java.home=C:/Users/xxxxf/.jdks/openjdk-23.0.2
 
 android.injected.testOnly=false
+
+android.suppressUnsupportedCompileSdk=37.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #
 # WebIDE - A powerful IDE for Android web development.
-# Copyright (C) 2025  ????  <3382198490@qq.com>
+# Copyright (C) 2025  如日中天  <3382198490@qq.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,10 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-#Fri Nov 21 01:01:29 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://mirrors.aliyun.com/gradle/distributions/v8.14.5/gradle-8.14.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 


### PR DESCRIPTION
- 在关于页面添加QQ群和Telegram频道链接卡片
- 实现点击整行跳转到相应社区的功能
- 使用Column配合clip和background替代Surface避免点击事件干扰
- 添加Monospace字体显示群号和用户名
- 更新Gradle版本从8.13到8.14.5并切换到阿里云镜像源
- 添加Android SDK编译抑制配置